### PR TITLE
Adding Travis-CI Support For Arm

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 # Config file for automatic testing at travis-ci.org
 
+arch:
+    - arm64
+    - amd64
 language: python
 
 python:


### PR DESCRIPTION
Travis-CI has added support for ARM64. Added ARM64 job in Travis-CI